### PR TITLE
Fix syntax errors in state_estimate.launch

### DIFF
--- a/spear_rover/launch/state_estimate.launch
+++ b/spear_rover/launch/state_estimate.launch
@@ -47,23 +47,23 @@
 		<param name = 'imu0' value = '/imu'/> <!--Can be set tot he map or odom frame-->
 
 		<rosparam param='odom0_config'>[false, false, false,
-						false, false, false,
-						true, true, true,
-						false,false,false
-						false,false,false]<rosparam/>
+                                                false, false, false,
+                                                true, true, true,
+                                                false, false, false,
+                                                false, false, false]</rosparam>
 
 
 		<rosparam param='imu0_config'>[false, false, false,
-						true, true, true,
-						false, false, false,
-						true,true,false
-						true,true,true]<rosparam/>
+                                               true, true, true,
+                                               false, false, false,
+                                               true,true,false,
+                                               true,true,true]</rosparam>
 
 		<rosparam param='rtab0_config'>[false, false, false,
-						false, false, false,
-						true, true, true,
-						false,false,false
-						false,false,false]<rosparam/>
+                                                false, false, false,
+                                                true, true, true,
+                                                false, false, false,
+                                                false, false, false]</rosparam>
 		<param name='odom0_differential' value='true'/>
 		<param name='imu0_differential' value='false'/>
 		<param name='rtab0_differential' value='false'/>
@@ -72,5 +72,5 @@
 		<param name='odom0_queue_size' value='10'/>
 		<param name='imu0_queue_size' value='10'/>
 		<param name='rtab0_queue_size' value='10'/>
-	<node/>
-<launch/>
+	</node>
+</launch>


### PR DESCRIPTION
ROS doesn't like it when there are tabs at the beginning of a line in a rosparam block so I replaced them with spaces. Also fixed syntax for some xml ending tags.