### PR TITLE
Add a node for moving via twist messages

### DIFF
--- a/spear_rover/CMakeLists.txt
+++ b/spear_rover/CMakeLists.txt
@@ -161,6 +161,7 @@ target_link_libraries(twist_to_skidsteer_node
 
 install(PROGRAMS
     nodes/mapper.py
+    nodes/move_with_twist.py
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/spear_rover/nodes/move_with_twist.py
+++ b/spear_rover/nodes/move_with_twist.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+
+import rospy
+from time import sleep, time
+from geometry_msgs.msg import Twist
+
+def main():
+    rospy.init_node('move_with_twist')
+    action = rospy.get_param('~action', 'forward')
+    duration = rospy.get_param('~duration', '5')
+    duration = float(duration)
+    frequency = 10
+
+    import sys
+    rospy.loginfo(sys.argv)
+
+    publisher = rospy.Publisher('/rover_diff_drive_controller/cmd_vel', Twist)
+
+    message = Twist()
+    if action == 'forward':
+        message.linear.x = 2
+    elif action == 'reverse':
+        message.linear.x = -2
+    elif action == 'left':
+        message.angular.z = 0.5
+    elif action == 'right':
+        message.angular.z = -0.5
+    
+    rospy.loginfo('Movement started: %s.' % str(message))
+    initial_time = time()
+    while True:
+        publisher.publish(message)
+        if (time() - initial_time) > duration:
+            break
+        sleep(1/frequency)
+
+    rospy.loginfo('Movement finished.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The node is spear_rover/move_with_twist.py. It accepts two arguments:

- action: one of "forward", "reverse", "left", or "right" (defaults to "forward")
- duration: number of seconds to send twist messages (defaults to 5)