### PR TITLE
Move dependencies to xml

### DIFF
--- a/spear-env.Dockerfile
+++ b/spear-env.Dockerfile
@@ -12,8 +12,6 @@ RUN apt-get update && apt-get install -y qt4-default libx264-dev \
                                          libgstreamer-plugins-base0.10-dev \
                                          ros-kinetic-rtabmap-ros \
                                          ros-kinetic-move-base \
-                                         ros-kinetic-gazebo-plugins \
-                                         ros-kinetic-hector-gazebo-plugins \
                                          gstreamer0.10-plugins-good \
                                          python-pip \
                                          tmux \

--- a/spear_simulator/package.xml
+++ b/spear_simulator/package.xml
@@ -16,5 +16,6 @@
   <exec_depend>diff_drive_controller</exec_depend>
   <exec_depend>move_base</exec_depend>
   <exec_depend>urdf_tutorial</exec_depend>
-
+  <exec_depend>gazebo_plugins</exec_depend>
+  <exec_depend>hector_gazebo_plugins</exec_depend>
 </package>


### PR DESCRIPTION
Earlier I put the gazebo gps and imu dependencies in the dockerfile. This commit fixes that.