### PR TITLE
Get *most* C++ autocompletion working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,14 @@
 __pycache__/
 **.swp
 .vscode/
+.clangd/
 
 # Generated when using our build.bash script. Useful for when you want to use
 # something like code completion in vim and have it recognize all the ros
 # packages.
 compile_commands.json
+compile_commands.original.json
+.docker-opt-ros-mount/
+.docker-root-ros-include-mount/
+
 arm_controls/dial.psd

--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ cd ~/ros
 catkin_make
 ```
 
+Or, if you also want to generate things like `compile-commands.json` (which gives us autocomplete within vim, emacs, etc...):
+
+```bash
+cd /software
+./build.bash
+```
+
 # Manual setup and install instructions
 
 ## Install Ubuntu 16.04 desktop

--- a/build.bash
+++ b/build.bash
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+#
+# Builds everything, while generating nicities like compile_commands.json,
+# making build-time config more consistent, and so on.
+#
+# All arguments passed to this script will be passed to catkin_make.
 
 ORIGINAL_DIR=$(pwd)
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -9,14 +14,10 @@ echo 'Changing directory to ros workspace.'
 cd ~/ros
 
 echo 'Building everything...'
-catkin_make -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+catkin_make -DCMAKE_EXPORT_COMPILE_COMMANDS=1 "$@"
 
 echo "Returning to ${ORIGINAL_DIR}."
 cd "${ORIGINAL_DIR}"
 
-# Check if we've symlinked the compile_commands.json file yet. If we haven't,
-# then do it!
-if [ ! -e "${SCRIPT_DIR}/compile_commands.json" ]; then
-	echo "Symlinking compile_commands.json (for code completion coolness)."
-	ln -s ~/ros/build/compile_commands.json ${SCRIPT_DIR}/compile_commands.json
-fi
+echo "Copying ~/ros/build/compile_commands.json to ${SCRIPT_DIR}/compile_commands.json (for code completion coolness)."
+cp ~/ros/build/compile_commands.json ${SCRIPT_DIR}/compile_commands.json

--- a/build.bash
+++ b/build.bash
@@ -20,4 +20,17 @@ echo "Returning to ${ORIGINAL_DIR}."
 cd "${ORIGINAL_DIR}"
 
 echo "Copying ~/ros/build/compile_commands.json to ${SCRIPT_DIR}/compile_commands.json (for code completion coolness)."
-cp ~/ros/build/compile_commands.json ${SCRIPT_DIR}/compile_commands.json
+# We need to globally replace all occurences of /opt/ros with $DOCKER_HOST_REPO_LOCATION/.docker-opt-ros-mount,
+# and all occurences of /root/ros/devel/include with $DOCKER_HOST_REPO_LOCATION/.docker-root-ros-include-mount,
+# so that all ros-related headers and libs will be picked up by autocomplete engines.
+cp ~/ros/build/compile_commands.json ${SCRIPT_DIR}/compile_commands.original.json
+cp -r /opt/ros/* /tmp/docker-opt-ros-mount/
+cp -r /root/ros/devel/include/* /tmp/docker-root-ros-include-mount/
+cat ${SCRIPT_DIR}/compile_commands.original.json \
+	| sed -e "s@/opt/ros@${DOCKER_HOST_REPO_LOCATION}/\.docker-opt-ros-mount@g" \
+	| sed -e "s@/root/ros/devel/include@${DOCKER_HOST_REPO_LOCATION}/\.docker-root-ros-include-mount@g" \
+	| sed -e "s@/root/ros/src/spear_rover@${DOCKER_HOST_REPO_LOCATION}/spear_rover@g" \
+	| sed -e "s@/root/ros/src/spear_simulator@${DOCKER_HOST_REPO_LOCATION}/spear_simulator@g" \
+	| sed -e "s@/root/ros/src/spear_msgs@${DOCKER_HOST_REPO_LOCATION}/spear_msgs@g" \
+	| sed -e "s@/root/ros/src/spear_station@${DOCKER_HOST_REPO_LOCATION}/spear_station@g" \
+	> ${SCRIPT_DIR}/compile_commands.json

--- a/run-docker.bash
+++ b/run-docker.bash
@@ -1,12 +1,19 @@
+# This directory is for mounting the ros includes in a way that autocomletion
+# engines can get to them.
+mkdir -p $(pwd)/.docker-opt-ros-mount
+
 # see: http://fabiorehm.com/blog/2014/09/11/running-gui-apps-with-docker/
 docker run \
     -it \
     -e DISPLAY \
     -e ROS_IP=127.0.0.1 \
     -e QT_X11_NO_MITSHM=1 \
+    -e DOCKER_HOST_REPO_LOCATION=$(pwd) \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     -v $XAUTHORITY:/root/.Xauthority  \
     -v $(pwd):/software  \
+    -v $(pwd)/.docker-opt-ros-mount:/tmp/docker-opt-ros-mount \
+    -v $(pwd)/.docker-root-ros-include-mount:/tmp/docker-root-ros-include-mount \
     --device=/dev/dri:/dev/dri \
     --net=host \
-    spear
+    spear bash -c 'echo "Copying ros headers from container /opt/ros to host-accessible location (for autocompletion)..." && mkdir -p /tmp/docker-opt-ros-mount && cp -r /opt/ros/* /tmp/docker-opt-ros-mount/ && echo "Doing the same with /root/ros/devel/include..." && mkdir -p /tmp/docker-root-ros-include-mount && cp -r /root/ros/devel/include/* /tmp/docker-root-ros-include-mount/ && echo -e "Success!\nRun the build.bash script to re-copy headers."; /ros_entrypoint.sh bash -l'

--- a/unpack.sh
+++ b/unpack.sh
@@ -103,6 +103,7 @@ ln -s ~/uavcan_dsdl/spear
 cd ~/ros
 # update rosdeps first
 rosdep install --from-paths src --ignore-src -r -y && \
-catkin_make --force && \
+cd $DIR && \
+./build.bash --force && \
 
 printf "Thanks for unpacking!\nNow that your enviroment is setup, you should never have to do this again.\nPlease run the following command to install the correct packages:\nrosdep install --from-paths src --ignore-src -r -y\n"

--- a/unpack.sh
+++ b/unpack.sh
@@ -103,7 +103,6 @@ ln -s ~/uavcan_dsdl/spear
 cd ~/ros
 # update rosdeps first
 rosdep install --from-paths src --ignore-src -r -y && \
-cd $DIR && \
-./build.bash --force && \
+catkin_make --force && \
 
 printf "Thanks for unpacking!\nNow that your enviroment is setup, you should never have to do this again.\nPlease run the following command to install the correct packages:\nrosdep install --from-paths src --ignore-src -r -y\n"


### PR DESCRIPTION
We now:
- Copy everything from /opt/ros and /root/ros/devel/include to
/tmp/.docker-opt-ros-mount and /tmp/.docker-root-ros-include-mount,
respectively, on each build
- Mount those two folders from the container's /tmp directory to the
host using docker volumes
- Use sed to modify the generated compile_commands.json to point to the
host machine mount points

This allows tools like Vim's YouCompleteMe, or really anything that
recognizes the standard compile_commands.json format, to find most of
the C++ headers required for code autocompletion.

Notable things that don't work:
- Anything that imports ros message types, as catkin does some sort of
voodoo black magic header generation and I can't find their location on
the file system.
- Anything that uses a system-wide C++ library that isn't managed by ros
and isn't installed on the host system. This includes things like Boost
(which is used fairly extensively throughout ros). You'll still get the
ros import names, but some tools will report errors when trying to
resolve types.
- Python 😢

Also, I think that there may be some new "remote debug server" things
being added to VSCode, which could make this patch irrelevant for VSCode
users. However, it really helps vim users, emacs users, and people who
run Linux in a VM and can't get VSCode reliably working (me).