### PR TITLE
Remove sudo command from spear-env.Dockerfile

### DIFF
--- a/spear-env.Dockerfile
+++ b/spear-env.Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y qt4-default libx264-dev \
                                          vim \
                                          nano
 RUN apt-get install -y libxml2-utils
-RUN sudo apt-get install -y python-catkin-tools
+RUN apt-get install -y python-catkin-tools
 RUN python -m pip install catkin_lint
 
 SHELL ["/ros_entrypoint.sh", "bash", "-c"]


### PR DESCRIPTION
Some people's docker images won't build when you use sudo commands in a Dockerfile. For some reason the travis build was still passing.