### PR TITLE
Fixed the simulator rover model so that it shows in the simulator

### DIFF
--- a/spear_simulator/models/rover/TARS_V2.urdf
+++ b/spear_simulator/models/rover/TARS_V2.urdf
@@ -435,15 +435,6 @@
     </joint>
 
     <link name="zed_camera_center">
-        <visual>
-            <origin xyz="0 0 0" rpy="0 0 0"/>
-            <geometry>
-                <mesh filename="package://zed_wrapper/urdf/models/ZED.stl" />
-            </geometry>
-            <material name="light_grey">
-                <color rgba="0.8 0.8 0.8 0.8"/>
-            </material>
-        </visual>
     </link>
 
 <!-- Left Camera -->


### PR DESCRIPTION
This commit removes the ZED camera model in camera_link in gazebo. We can add it back in later if we need to.