### PR TITLE
Move download model database into dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,9 @@ RUN cp .tmux/.tmux.conf.local .
 RUN sed -i '/#set -g mouse on/c\set -g mouse on' .tmux.conf.local
 WORKDIR /
 
+# Download gazebo model database
+RUN hg clone https://bitbucket.org/osrf/gazebo_models ~/.gazebo/models
+
 COPY . /software
 
 # Set IS_DOCKER to true so setup-vcan.bash and setup-can.bash don't try

--- a/unpack.sh
+++ b/unpack.sh
@@ -43,11 +43,6 @@ then
     source ~/ros/devel/setup.bash
 fi
 
-# Download gazebo model database
-if [ $DEV ]; then
-  hg clone https://bitbucket.org/osrf/gazebo_models ~/.gazebo/models
-fi
-
 # Add our models to GAZEBO_MODEL_PATH
 if ! grep -Fxq "export GAZEBO_MODEL_PATH=GAZEBO_MODEL_PATH:${DIR}/spear_simulator/models" ~/.bashrc
 then


### PR DESCRIPTION
Downloading the gazebo model database used to be in unpack.sh. Some of the simulator worlds use assets from that database, which are downloaded at runtime as needed. Downloading them all in unpack.sh was meant to trade that runtime penalty for a longer build time.

But everything in unpack.sh is always re-run whenever the docker image is rebuilt (it happens after the COPY and so has no caching). So, this PR moves the download into the Dockerfile so it can be cached.

The disadvantage here is there is no longer a check if we're in "dev" mode to download the models, so they will also be in the rover's docker image and take up space. But since we don't actually have a good way to build the rover's version of the image (short of manually editing `docker-compose.yml`), this doesn't seem like much more of a downside than is already there.