### PR TITLE
Remove gains from arm controller parameters

### DIFF
--- a/spear_rover/config/controllers.yaml
+++ b/spear_rover/config/controllers.yaml
@@ -51,32 +51,6 @@ arm_controller:
         - elbow_pitch
         - wrist_pitch
         - wrist_roll
-    gains:
-        shoulder_yaw:
-            p: 100
-            d: 1
-            i: 1
-            i_clamp: 1
-        shoulder_pitch:
-            p: 100
-            d: 1
-            i: 1
-            i_clamp: 1
-        elbow_pitch:
-            p: 100
-            d: 1
-            i: 1
-            i_clamp: 1
-        wrist_pitch:
-            p: 100
-            d: 1
-            i: 1
-            i_clamp: 1
-        wrist_roll:
-            p: 100
-            d: 1
-            i: 1
-            i_clamp: 1
 
 # This is called a "controller" but is not. It is actually way to publish
 # the arm/wheel joint angles to /joint_states, since the controllers don't do


### PR DESCRIPTION
The arm controller parameters had a `gains` parameter. This is not used with position controllers (and the arm seems to function fine without it), so I removed the parameter.