### PR TITLE
Add demo IK node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y qt4-default libx264-dev \
 
 RUN python -m pip install catkin_lint || echo "Error installing catkin_lint -- this is not a problem on the tx2"
 RUN python -m pip install typing
+RUN python -m pip install pygame ikpy
 
 # Install uavcan_gui_tool for can debugging / monitoring
 # (see https://uavcan.org/GUI_Tool/Overview/ for install docs)

--- a/spear_rover/CMakeLists.txt
+++ b/spear_rover/CMakeLists.txt
@@ -140,6 +140,7 @@ target_link_libraries(hardware_node
 install(PROGRAMS
     nodes/mapper.py
     nodes/move_with_twist.py
+    nodes/arm_ik.py
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/spear_rover/nodes/arm_ik.py
+++ b/spear_rover/nodes/arm_ik.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+import math
+from tempfile import TemporaryFile
+
+import ikpy
+import numpy as np
+import pygame
+import rospy
+import tf2_geometry_msgs
+import tf2_ros
+from control_msgs.srv import QueryTrajectoryState
+from geometry_msgs.msg import PointStamped
+from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
+
+
+class JointAngles:
+    def __init__(self, angles):
+        self._angles = angles
+
+    def to_command(self, time_from_start):
+        trajectory = JointTrajectory()
+        trajectory.joint_names = self._angles.keys()
+        trajectory.points = [JointTrajectoryPoint()]
+        trajectory.points[0].positions = self._angles.values()
+        trajectory.points[0].time_from_start = time_from_start
+        return trajectory
+
+
+class IK:
+    def __init__(self, robot_description, valid_joints, base_joint):
+        self.valid_joints = valid_joints
+        self.base_joint = base_joint
+        with TemporaryFile() as file:
+            file.write(robot_description)
+            file.seek(0)
+            self.chain = ikpy.chain.Chain.from_urdf_file(file, [base_joint])
+
+    def backward(self, target_position):
+        angles = self.chain.inverse_kinematics(target_position)
+        joints = [link.name for link in self.chain.links]
+        return JointAngles({
+            name: angle
+            for name, angle in zip(joints, angles) if name in self.valid_joints
+        })
+
+    def frame(self):
+        return self.base_joint
+
+
+class Target:
+    def __init__(self, frame_id):
+        self._frame_id = frame_id
+        self._yaw = 0
+        self._pitch = 0
+        self._radius = 1
+        self._tf_buffer = tf2_ros.Buffer()
+        self._tf_listener = tf2_ros.TransformListener(self._tf_buffer)
+
+    def cw(self, angle):
+        self._yaw -= angle
+
+    def ccw(self, angle):
+        self._yaw += angle
+
+    def up(self, angle):
+        self._pitch += angle
+
+    def down(self, angle):
+        self._pitch -= angle
+
+    def retract(self, value):
+        self._radius -= value
+
+    def expand(self, value):
+        self._radius += value
+
+    def position(self, frame_id=None):
+        point = self.point(frame_id)
+        return np.array([point.point.x, point.point.y, point.point.z])
+
+    def point(self, frame_id=None):
+        point = PointStamped()
+        point.header.frame_id = self._frame_id
+        point.point.x, point.point.y, point.point.z = np.array([
+            np.cos(self._yaw) * np.cos(self._pitch),
+            np.sin(self._yaw),
+            np.sin(self._pitch)
+        ]) * self._radius
+
+        if frame_id is not None:
+            while not rospy.is_shutdown():
+                try:
+                    transform = self._tf_buffer.lookup_transform(
+                        target_frame=frame_id,
+                        source_frame=self._frame_id,
+                        time=rospy.Time(0),
+                        timeout=rospy.Duration(0.1))
+                    point = tf2_geometry_msgs.do_transform_point(
+                        point, transform)
+                    break
+                except Exception as err:
+                    rospy.logerr(err)
+        return point
+
+
+rospy.init_node('arm_ik')
+rospy.sleep(0)
+
+arm_command_publisher = rospy.Publisher('/arm_controller/command',
+                                        JointTrajectory,
+                                        queue_size=1)
+target_point_publisher = rospy.Publisher('/arm_target',
+                                         PointStamped,
+                                         queue_size=1)
+
+rospy.wait_for_service('/arm_controller/query_state')
+query_trajectory_state = rospy.ServiceProxy('/arm_controller/query_state',
+                                            QueryTrajectoryState)
+joint_names = query_trajectory_state(rospy.Time.now()).name
+
+robot_description = rospy.get_param('robot_description')
+ik = IK(robot_description, joint_names, 'arm_mount')
+target = Target('arm_mount')
+target.up(-math.pi / 6)
+target.cw(math.pi)
+target.retract(0.5)
+
+pygame.init()
+pygame.display.set_mode((100, 100))
+pygame.display.set_caption('IK Controller')
+
+
+def key_pressed(key):
+    index = pygame.__dict__['K_' + key]
+    return pygame.key.get_pressed()[index]
+
+
+rate = rospy.Rate(10)
+while not rospy.is_shutdown():
+    position = target.position(ik.frame())
+    trajectory = ik.backward(position).to_command(rospy.Duration(0.01))
+    arm_command_publisher.publish(trajectory)
+    target_point_publisher.publish(target.point())
+
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            pygame.quit()
+            break
+    if key_pressed('a'):
+        target.ccw(0.05)
+    if key_pressed('d'):
+        target.cw(0.05)
+    if key_pressed('w'):
+        target.up(0.05)
+    if key_pressed('s'):
+        target.down(0.05)
+    if key_pressed('e'):
+        target.expand(0.01)
+    if key_pressed('q'):
+        target.retract(0.01)
+
+    rate.sleep()

--- a/spear_rover/rviz/drive.rviz
+++ b/spear_rover/rviz/drive.rviz
@@ -9,7 +9,7 @@ Panels:
         - /Image1
         - /PointCloud21
       Splitter Ratio: 0.5
-    Tree Height: 554
+    Tree Height: 525
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -64,7 +64,16 @@ Visualization Manager:
         Expand Link Details: false
         Expand Tree: false
         Link Tree Style: Links in Alphabetic Order
+        arm_mount:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
         base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bicep:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -73,6 +82,16 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
+        finger:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        forearm:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
         imu_link:
           Alpha: 1
           Show Axes: false
@@ -129,6 +148,41 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
+        palm:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        shoulder:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        wrist:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        zed_camera_center:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        zed_left_camera_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        zed_left_camera_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        zed_right_camera_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        zed_right_camera_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
       Name: RobotModel
       Robot Description: robot_description
       TF Prefix: ""
@@ -182,7 +236,7 @@ Visualization Manager:
       Marker Topic: /visualization_marker
       Name: Marker
       Namespaces:
-        basic_shapes: true
+        {}
       Queue Size: 100
       Value: true
     - Class: rviz/Marker
@@ -190,8 +244,18 @@ Visualization Manager:
       Marker Topic: /visualization_marker
       Name: Marker
       Namespaces:
-        basic_shapes: true
+        {}
       Queue Size: 100
+      Value: true
+    - Alpha: 1
+      Class: rviz/PointStamped
+      Color: 204; 41; 204
+      Enabled: true
+      History Length: 1
+      Name: PointStamped
+      Radius: 0.20000000298023224
+      Topic: /arm_target
+      Unreliable: false
       Value: true
   Enabled: true
   Global Options:
@@ -244,12 +308,12 @@ Visualization Manager:
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 1053
+  Height: 1016
   Hide Left Dock: false
   Hide Right Dock: false
   Image:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000020500000383fc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003b000002b3000000c700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d00610067006501000002f4000000ca0000001600ffffff000000010000010f00000383fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003b00000383000000a000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073d0000003efc0100000002fb0000000800540069006d006501000000000000073d0000024400fffffffb0000000800540069006d006501000000000000045000000000000000000000041d0000038300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000400000000000002050000035efc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003b00000296000000c700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d00610067006501000002d7000000c20000001600ffffff000000010000010f0000035efc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003b0000035e000000a000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007380000003efc0100000002fb0000000800540069006d00650100000000000007380000024400fffffffb0000000800540069006d00650100000000000004500000000000000000000004180000035e00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -258,6 +322,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  Width: 1853
-  X: 67
+  Width: 1848
+  X: 72
   Y: 27

--- a/spear_rover/rviz/navigate.rviz
+++ b/spear_rover/rviz/navigate.rviz
@@ -11,7 +11,7 @@ Panels:
         - /Odometry4/Shape1
         - /Odometry5/Shape1
       Splitter Ratio: 0.6284916400909424
-    Tree Height: 574
+    Tree Height: 525
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -66,7 +66,16 @@ Visualization Manager:
         Expand Link Details: false
         Expand Tree: false
         Link Tree Style: Links in Alphabetic Order
+        arm_mount:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
         base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bicep:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -75,6 +84,16 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
+        finger:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        forearm:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
         imu_link:
           Alpha: 1
           Show Axes: false
@@ -131,6 +150,41 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
+        palm:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        shoulder:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        wrist:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        zed_camera_center:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        zed_left_camera_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        zed_left_camera_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        zed_right_camera_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        zed_right_camera_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
       Name: RobotModel
       Robot Description: robot_description
       TF Prefix: ""
@@ -202,8 +256,8 @@ Visualization Manager:
     - Alpha: 1
       Autocompute Intensity Bounds: true
       Autocompute Value Bounds:
-        Max Value: 0.3487774133682251
-        Min Value: -0.45262712240219116
+        Max Value: -9999
+        Min Value: 9999
         Value: true
       Axis: Z
       Channel Name: intensity
@@ -457,7 +511,7 @@ Visualization Manager:
       Marker Topic: /visualization_marker
       Name: Marker
       Namespaces:
-        basic_shapes: true
+        {}
       Queue Size: 100
       Value: true
     - Alpha: 1
@@ -468,6 +522,16 @@ Visualization Manager:
       Name: PointStamped
       Radius: 0.20000000298023224
       Topic: /viz/proportional_drive/target_position
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Class: rviz/PointStamped
+      Color: 204; 41; 204
+      Enabled: true
+      History Length: 1
+      Name: PointStamped
+      Radius: 0.20000000298023224
+      Topic: /arm_target
       Unreliable: false
       Value: true
   Enabled: true
@@ -521,12 +585,12 @@ Visualization Manager:
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 1080
+  Height: 1016
   Hide Left Dock: false
   Hide Right Dock: false
   Image:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd0000000400000000000001560000039efc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003b000002c7000000c700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d0061006700650100000308000000d10000001600fffffffb0000000c00430061006d00650072006101000003a9000000160000000000000000000000010000010f0000039efc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003b0000039e000000a000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073d0000003efc0100000002fb0000000800540069006d006501000000000000073d0000024400fffffffb0000000800540069006d00650100000000000004500000000000000000000004cc0000039e00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000400000000000001560000035efc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003b00000296000000c700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d00610067006501000002d7000000c20000001600fffffffb0000000c00430061006d00650072006101000003a9000000160000000000000000000000010000010f0000035efc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003b0000035e000000a000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007380000003efc0100000002fb0000000800540069006d00650100000000000007380000024400fffffffb0000000800540069006d00650100000000000004500000000000000000000004c70000035e00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -535,6 +599,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  Width: 1853
-  X: 67
-  Y: 0
+  Width: 1848
+  X: 72
+  Y: 27

--- a/spear_simulator/models/rover/arm.urdf.xacro
+++ b/spear_simulator/models/rover/arm.urdf.xacro
@@ -46,7 +46,7 @@
   <joint name="arm_mount" type="fixed">
     <parent link="base_link"/>
     <child link="arm_mount"/>
-    <origin xyz="0.25 0 0.3"/>
+    <origin xyz="0.25 0 0.3" rpy="0 0 3.1415926535897"/>
   </joint>
 
   <link name="arm_mount">
@@ -111,7 +111,7 @@
     <parent link="palm"/>
     <child link="finger"/>
     <axis xyz="1 0 0"/>
-    <origin xyz="0 0 ${palm_length}"/>
+    <origin xyz="0 0 ${palm_length}" rpy="0 0 0"/>
     <limit lower="-1" upper="1" effort="1" velocity="0.5"/>
   </container></xacro:arm_joint>
 


### PR DESCRIPTION
Adds a node which illustrates the use of ikpy to move the arm. Also changes the transform of `arm_mount` to get rid of an ik singularity when the arm is facing forward (now it happens when the arm is facing backward, which should not be a problem).

Right now the demo doesn't use `moveit` at all. The disadvantage is that `ikpy` doesn't know about self-collisions or constraints. The advantage is it doesn't need the massive amount of configuration that moveit does (that configuration is already done, but it would be kind of nice to remove it to make the code easier to understand).

An alternate approach would be to use `ikpy` to generate arm angles, and then pass those to `moveit` as a target.