### PR TITLE
Add installation of python package `monotonic` in unpack.sh

### DIFF
--- a/unpack.sh
+++ b/unpack.sh
@@ -89,6 +89,7 @@ python -m pip install uavcan
 mkdir -p ~/uavcan_vendor_specific_types
 cd ~/uavcan_vendor_specific_types
 ln -s ~/ros/src/uavcan_dsdl/spear
+python -m pip install monotonic # Dependency for canros
 
 ###### Link our packages
 # This needs to be moved all back into rover2 at some point


### PR DESCRIPTION
This package is a depedency for canros.

I recently got the following error when trying to run `docker-compose` build on my machine:

```
_______________________________________________________________________________
Errors << canros:cmake /root/ros/logs/canros/build.cmake.000.log               
The package 'monotonic' is not available, the library will use real time instead of monotonic time.
This implies that the library may misbehave if system clock is adjusted while the library is running.
In order to fix this problem, consider either option:
 1. Switch to Python 3.
 2. Install the missing package, e.g. using pip:
    pip install monotonic
Traceback (most recent call last):
  File "/root/ros/src/canros/scripts/generate.py", line 18, in <module>
    import canros
  File "/root/ros/src/canros/src/canros/__init__.py", line 4, in <module>
    import monotonic   # pip install monotonic
ImportError: No module named monotonic
CMake Error at /opt/ros/melodic/share/genmsg/cmake/genmsg-extras.cmake:94 (message):
  add_message_files() directory not found: /root/ros/src/canros/msg
Call Stack (most recent call first):
  CMakeLists.txt:51 (add_message_files)cd /root/ros/build/canros; catkin build --get-env canros | catkin env -si  /usr/bin/cmake /root/ros/src/canros --no-warn-unused-cli -DCATKIN_DEVEL_PREFIX=/root/ros/devel/.private/canros -DCMAKE_INSTALL_PREFIX=/root/ros/install; cd -
...............................................................................
Failed << canros:cmake                             [ Exited with code 1 ]
```

This commit fixes the error. However, I am not sure why this error happened to me now and hasn't happened before.

The last build on docker hub from the master branch succeeded: https://hub.docker.com/repository/docker/spaceualberta/ros

Futhermore, there are no new commits in the canros repo since 2018: https://github.com/MonashUAS/canros/commits/master