### PR TITLE
Fix ikpy verson at 3.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update && apt-get install -y qt4-default libx264-dev \
 
 RUN python -m pip install catkin_lint || echo "Error installing catkin_lint -- this is not a problem on the tx2"
 RUN python -m pip install typing
-RUN python -m pip install pygame ikpy
+# Later versions of ikpy drop Python 2 support
+RUN python -m pip install pygame ikpy==3.0.1
 
 # Install uavcan_gui_tool for can debugging / monitoring
 # (see https://uavcan.org/GUI_Tool/Overview/ for install docs)


### PR DESCRIPTION
The next version of ikpy drops support for Python 2. Until we upgrade to ros noetic or foxy we need to use an older version of ikpy.