### PR TITLE
Run image_saver in station adapter launch file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update && apt-get install -y qt4-default libx264-dev \
 
 RUN python -m pip install catkin_lint || echo "Error installing catkin_lint -- this is not a problem on the tx2"
 RUN python -m pip install typing
-RUN python -m pip install pygame ikpy
+# Later versions of ikpy drop Python 2 support
+RUN python -m pip install pygame ikpy==3.0.1
 
 # Install uavcan_gui_tool for can debugging / monitoring
 # (see https://uavcan.org/GUI_Tool/Overview/ for install docs)

--- a/spear_rover/launch/station_adapter.launch
+++ b/spear_rover/launch/station_adapter.launch
@@ -19,7 +19,7 @@
     <param name="decimation_y" value="4"/>
   </node>
 
-  <!-- Save full-size camera stills -->
+  <!-- Save full-size camera images -->
   <arg name="filename_format" value="$(arg image_dest)/image%04i.%s"/>
   <node pkg="image_view" type="image_saver" name="image_saver">
     <remap from="image" to="/camera_depth/rgb/image_raw"/>

--- a/spear_rover/launch/station_adapter.launch
+++ b/spear_rover/launch/station_adapter.launch
@@ -1,6 +1,7 @@
 <!-- Handles comms with the station -->
 <launch>
   <arg name="station"/>
+  <arg name="image_dest" default="$(find spear_rover)/../images"/>
 
   <!-- Set up topic transport across the network -->
   <include file="$(find spear_rover)/launch/nimbro_network.launch">
@@ -16,5 +17,13 @@
 
     <param name="decimation_x" value="4"/>
     <param name="decimation_y" value="4"/>
+  </node>
+
+  <!-- Save full-size camera stills -->
+  <arg name="filename_format" value="$(arg image_dest)/image%04i.%s"/>
+  <node pkg="image_view" type="image_saver" name="image_saver">
+    <remap from="image" to="/camera_depth/rgb/image_raw"/>
+    <param name="filename_format" value="$(arg filename_format)"/>
+    <param name="save_all_image" value="false"/>
   </node>
 </launch>

--- a/spear_rover/package.xml
+++ b/spear_rover/package.xml
@@ -35,6 +35,7 @@
   <exec_depend>diff_drive_controller</exec_depend>
   <exec_depend>flexbe_onboard</exec_depend>
   <exec_depend>image_proc</exec_depend>
+  <exec_depend>image_view</exec_depend>
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>nimbro_service_transport</exec_depend>


### PR DESCRIPTION
For #223 , which basically already done, but this is a way to get full-sized images instead of the lower-quality ones streamed to the station.