### PR TITLE
Add gripper to arm

### DIFF
--- a/catkin_lint.bash
+++ b/catkin_lint.bash
@@ -12,5 +12,6 @@ python -m catkin_lint ~/ros/src \
   --skip-pkg tf_throttle \
   --skip-pkg flexbe_app \
   --skip-pkg ros_numpy \
+  --skip-pkg roboticsgroup_upatras_gazebo_plugins \
   -W2 \
   "$@"

--- a/spear_rover/config/controllers.yaml
+++ b/spear_rover/config/controllers.yaml
@@ -51,6 +51,7 @@ arm_controller:
         - elbow_pitch
         - wrist_pitch
         - wrist_roll
+        - grab
 
 # This is called a "controller" but is not. It is actually way to publish
 # the arm/wheel joint angles to /joint_states, since the controllers don't do

--- a/spear_simulator/models/rover/arm.urdf.xacro
+++ b/spear_simulator/models/rover/arm.urdf.xacro
@@ -11,7 +11,7 @@
   <xacro:property name="arm_width" value="0.1" />
   <xacro:property name="joint_sep" value="0.005" />
 
-  <xacro:macro name="arm_link" params="name length">
+  <xacro:macro name="arm_link" params="name length width:=${arm_width}">
     <link name="${name}">
       <visual>
         <origin xyz="0 0 ${length/2}" rpy="0 0 0"/>
@@ -109,13 +109,47 @@
 
   <xacro:arm_joint name="grab"><container>
     <parent link="palm"/>
-    <child link="finger"/>
+    <child link="grab_placeholder"/>
     <axis xyz="1 0 0"/>
-    <origin xyz="0 0 ${palm_length}" rpy="0 0 0"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
     <limit lower="-1" upper="1" effort="1" velocity="0.5"/>
   </container></xacro:arm_joint>
 
-  <arm_link name="finger" length="${finger_length}"/>
+  <link name="grab_placeholder">
+    <inertial>
+      <mass value="0.001" />
+      <inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.001" iyz="0.0" izz="0.001" />
+    </inertial>
+  </link>
+
+  <!-- These joints cannot have a transmission, since they are not controlled by gazebo_ros_control -->
+  <joint name="knuckle1" type="revolute">
+    <parent link="palm"/>
+    <child link="finger1"/>
+    <axis xyz="1 0 0"/>
+    <origin xyz="0 0.03 ${palm_length}" rpy="0 0 0"/>
+    <limit lower="-1" upper="1" effort="1" velocity="0.5"/>
+  </joint>
+  <joint name="knuckle2" type="revolute">
+    <parent link="palm"/>
+    <child link="finger2"/>
+    <axis xyz="-1 0 0"/>
+    <origin xyz="0 -0.03 ${palm_length}" rpy="0 0 0"/>
+    <limit lower="-1" upper="1" effort="1" velocity="0.5"/>
+  </joint>
+
+  <xacro:arm_link name="finger1" length="${finger_length}" width="0.05"/>
+  <xacro:arm_link name="finger2" length="${finger_length}" width="0.05"/>
+
+  <gazebo>
+    <plugin filename="libroboticsgroup_upatras_gazebo_mimic_joint_plugin.so" name="mimic_joint">
+      <joint>grab</joint>
+      <mimicJoint>knuckle1</mimicJoint>
+    </plugin>
+    <plugin filename="libroboticsgroup_upatras_gazebo_mimic_joint_plugin.so" name="mimic_joint">
+      <joint>grab</joint>
+      <mimicJoint>knuckle2</mimicJoint>
+    </plugin>
+  </gazebo>
 
 </robot>
-

--- a/spear_simulator/models/rover/arm.urdf.xacro
+++ b/spear_simulator/models/rover/arm.urdf.xacro
@@ -8,7 +8,7 @@
   <xacro:property name="finger_length" value="${forearm_length/3}" />
   <xacro:property name="hand_length" value="0.59" />
   
-  <xacro:property name="arm_width" value="0.05" />
+  <xacro:property name="arm_width" value="0.1" />
   <xacro:property name="joint_sep" value="0.005" />
 
   <xacro:macro name="arm_link" params="name length">
@@ -16,7 +16,7 @@
       <visual>
         <origin xyz="0 0 ${length/2}" rpy="0 0 0"/>
         <geometry>
-          <cylinder length="${length-joint_sep}" radius="${arm_width}"/>
+          <cylinder length="${length-joint_sep}" radius="${width/2}"/>
         </geometry>
       </visual>
       <inertial>

--- a/spear_simulator/package.xml
+++ b/spear_simulator/package.xml
@@ -13,5 +13,6 @@
   <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>hector_gazebo_plugins</exec_depend>
   <exec_depend>nodelet</exec_depend>
+  <exec_depend>roboticsgroup_upatras_gazebo_plugins</exec_depend>
   <exec_depend>rtabmap_ros</exec_depend>
 </package>

--- a/unpack.sh
+++ b/unpack.sh
@@ -75,6 +75,7 @@ repos=(
     eric-wieser/ros_numpy
     AIS-Bonn/nimbro_network
     UofA-SPEAR/uavcan_dsdl
+    roboticsgroup/roboticsgroup_upatras_gazebo_plugins
 )
 
 cd ~/ros/src


### PR DESCRIPTION
This is not polished, but it adds a gripper to the arm. The gripper is controlled via the _grab_ joint. Depending on the gears used in the actual robot, the amount _grab_ turns will have to be scaled when turning the real gripper control motor. This could be done in firmware or potentially by adding a transmission to the gazebo model.