### PR TITLE
Add a way to save and restore state machine 

### DIFF
--- a/pkg/spear_planner/CMakeLists.txt
+++ b/pkg/spear_planner/CMakeLists.txt
@@ -1,0 +1,202 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(spear_planner)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+# add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a exec_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs  # Or other packages containing msgs
+# )
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES spear_planner
+#  CATKIN_DEPENDS other_catkin_pkg
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+# include
+# ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a C++ library
+# add_library(${PROJECT_NAME}
+#   src/${PROJECT_NAME}/spear_planner.cpp
+# )
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
+## With catkin_make all packages are built within a single CMake context
+## The recommended prefix ensures that target names across packages don't collide
+# add_executable(${PROJECT_NAME}_node src/planner_node.cpp)
+
+## Rename C++ executable without prefix
+## The above recommended prefix causes long target names, the following renames the
+## target back to the shorter version for ease of user use
+## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
+# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+# target_link_libraries(${PROJECT_NAME}_node
+#   ${catkin_LIBRARIES}
+# )
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# catkin_install_python(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables for installation
+## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_executables.html
+# install(TARGETS ${PROJECT_NAME}_node
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark libraries for installation
+## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_libraries.html
+# install(TARGETS ${PROJECT_NAME}
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_planner.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+catkin_add_nosetests(python/spear_planner)

--- a/pkg/spear_planner/CMakeLists.txt
+++ b/pkg/spear_planner/CMakeLists.txt
@@ -7,7 +7,9 @@ project(spear_planner)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS
+    smach
+)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -16,7 +18,7 @@ find_package(catkin REQUIRED)
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
 ## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
+catkin_python_setup()
 
 ################################################
 ## Declare ROS messages, services and actions ##
@@ -199,4 +201,6 @@ include_directories(
 # endif()
 
 ## Add folders to be run by python nosetests
-catkin_add_nosetests(python/spear_planner)
+if(CATKIN_ENABLE_TESTING)
+    catkin_add_nosetests(python/${PROJECT_NAME})
+endif()

--- a/pkg/spear_planner/package.xml
+++ b/pkg/spear_planner/package.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>spear_planner</name>
+  <version>0.0.0</version>
+  <description>Mission planning utilities and other "glue"</description>
+  <maintainer email="rain.epp@ualberta.ca">Rain Epp</maintainer>
+  <license>TODO</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>smach</depend>
+
+  <test_depend>rosunit</test_depend>
+</package>

--- a/pkg/spear_planner/python/spear_planner/history.py
+++ b/pkg/spear_planner/python/spear_planner/history.py
@@ -48,7 +48,6 @@ class ResumableStateMachine(StateMachine):
 
             child._request_resume(remaining_save_states)
 
-
     def execute(self, parent_ud: UserData = UserData()):
         if self._resume_save_state is not None:
             resume_label = self._resume_save_state.label

--- a/pkg/spear_planner/python/spear_planner/history.py
+++ b/pkg/spear_planner/python/spear_planner/history.py
@@ -1,0 +1,136 @@
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, List, Tuple, Union
+from uuid import UUID, uuid4
+
+from smach import StateMachine
+from smach.container import Container
+from smach.user_data import UserData
+
+
+@dataclass
+class ContainerSaveState:
+    """
+    Checkpoint for a single non-nested container. The checkpoint represents the
+    state of the container right before the state labelled `label` is executed.
+    `userdata` stores the userdata as passed into execute() (i.e. not the
+    parent userdata).
+    """
+    label: str
+    userdata: UserData
+
+
+@dataclass
+class Checkpoint:
+    uid: UUID
+    timestamp: datetime
+    save_states: List[ContainerSaveState]
+
+
+class ResumableStateMachine(StateMachine):
+    """
+    A StateMachine variant which can be started from any checkpoint.
+    """
+    def __init__(self, outcomes: List[str], input_keys: List[str] = [], output_keys: List[str] = []):
+        super().__init__(outcomes, input_keys=input_keys, output_keys=output_keys)
+        self._resume_save_state = None
+
+    def _request_resume(self, save_states: List[ContainerSaveState]):
+        save_state, *remaining_save_states = save_states
+        if save_state.label not in self.get_children():
+            raise ValueError(f'Cannot resume to state {save_state} as it does not exist in this state machine')
+        self._resume_save_state = save_state
+        if len(remaining_save_states) > 0:
+            child = self.get_children()[save_state.label]
+            if not isinstance(child, ResumableStateMachine):
+                raise ValueError(f'Cannot resume non-resumable state {save_state.label}')
+
+            child._request_resume(remaining_save_states)
+
+
+    def execute(self, parent_ud: UserData = UserData()):
+        if self._resume_save_state is not None:
+            resume_label = self._resume_save_state.label
+            resume_ud = self._resume_save_state.userdata
+            self._resume_save_state = None
+            # Skip directly to the state we want
+            old_initial_states = self.get_initial_states()
+            self.set_initial_state([resume_label], resume_ud)
+            # Prevent values in parent userdata being written into this userdata
+            # XXX: This almost certainly won't work if you use remappings.
+            input_keys_to_remove = self._input_keys & set(resume_ud.keys())
+            self._input_keys -= input_keys_to_remove
+            try:
+                return super().execute(parent_ud=parent_ud)
+            finally:
+                self.set_initial_state(old_initial_states)
+                self._input_keys |= input_keys_to_remove
+        else:
+            return super().execute(parent_ud=parent_ud)
+
+    def execute_from(self, checkpoint: Checkpoint, parent_ud: UserData = UserData()) -> Union[str, None]:
+        self._request_resume(checkpoint.save_states)
+        return self.execute(parent_ud)
+
+
+class ContainerHistory:
+    def __init__(self, container: Container):
+        self._current_uds: Dict[Tuple[str, ...], UserData] = {}
+        self._current_labels: Tuple[str, ...] = ()
+        self._checkpoints: List[Checkpoint] = []
+        self._register_callbacks(container, tuple())
+
+    def _register_callbacks(self, container: Container, labels: Tuple[str, ...]):
+        container.register_start_cb(self._start_cb, [labels])
+        container.register_transition_cb(self._transition_cb, [labels])
+        container.register_termination_cb(self._termination_cb, [labels])
+        for child_label, child in container.get_children().items():
+            if isinstance(child, Container):
+                self._register_callbacks(child, (*labels, child_label))
+
+    @staticmethod
+    def _clone_ud(ud: UserData):
+        new_ud = UserData()
+        for key in ud.keys():
+            new_ud[key] = deepcopy(ud[key])
+        return new_ud
+
+    def _start_cb(self, userdata: UserData, initial_states: List[str], labels: Tuple[str, ...]):
+        labels = (*labels, initial_states[0])
+        self._current_uds[labels] = self._clone_ud(userdata)
+        self._current_labels = labels
+        self.save()
+
+    def _transition_cb(self, userdata: UserData, active_states: List[str], labels: Tuple[str, ...]):
+        labels = (*labels, active_states[0])
+        self._current_uds[labels] = self._clone_ud(userdata)
+        self._current_labels = labels
+        self.save()
+
+    def _termination_cb(self, userdata: UserData, terminal_states: List[str], outcome: str, labels: Tuple[str, ...]):
+        # Nothing to do here, really, since we save checkpoints *before* a state
+        # is executed and not after.
+        pass
+
+    def save(self):
+        save_states = []
+        for i in range(1, len(self._current_labels) + 1):
+            key = tuple(self._current_labels[:i])
+            label = key[-1]
+            userdata = self._current_uds[key]
+            save_states.append(ContainerSaveState(label, userdata))
+
+        self._checkpoints.append(Checkpoint(
+            uid=uuid4(),
+            timestamp=datetime.now(),
+            save_states=save_states,
+        ))
+
+    @property
+    def checkpoints(self):
+        return self._checkpoints
+
+    @property
+    def latest_checkpoint(self):
+        return self._checkpoints[-1]

--- a/pkg/spear_planner/python/spear_planner/test_history.py
+++ b/pkg/spear_planner/python/spear_planner/test_history.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-PKG = 'spear_planner'
 from unittest import TestCase, TestSuite
 from spear_planner.history import Checkpoint, ContainerHistory, ContainerSaveState, ResumableStateMachine
 
@@ -9,16 +8,19 @@ from smach.user_data import UserData
 from uuid import uuid4
 from datetime import datetime
 
+PKG = 'spear_planner'
+
 
 class TestResumableStateMachine(TestCase):
     def setUp(self) -> None:
         self._trace = []
 
     def simple_sm(self):
-        sm = ResumableStateMachine(outcomes=['ok'])
         def execute(name):
             self._trace.append(name)
             return 'ok'
+
+        sm = ResumableStateMachine(outcomes=['ok'])
         with sm:
             StateMachine.add('A', CBState(lambda ud: execute('A'), outcomes=['ok']), {'ok': 'B'})
             StateMachine.add('B', CBState(lambda ud: execute('B'), outcomes=['ok']), {'ok': 'C'})
@@ -26,10 +28,11 @@ class TestResumableStateMachine(TestCase):
         return sm
 
     def sm_with_userdata(self):
-        sm = ResumableStateMachine(outcomes=['ok'], input_keys=['key'])
         def execute(name, outcome):
             self._trace.append(name)
             return outcome
+
+        sm = ResumableStateMachine(outcomes=['ok'], input_keys=['key'])
         with sm:
             StateMachine.add('A', CBState(lambda ud: execute('A', ud['key']), outcomes=['B'], io_keys=['key']), {'B': 'B'})
             StateMachine.add('B', CBState(lambda ud: execute('B', ud['key']), outcomes=['ok'], input_keys=['key']))
@@ -43,7 +46,7 @@ class TestResumableStateMachine(TestCase):
         resumable_inner_sm = ResumableStateMachine(outcomes=['ok'])
         inner_sm = StateMachine(outcomes=['ok'])
         outer_sm = ResumableStateMachine(outcomes=['ok'])
-       
+
         with outer_sm:
             StateMachine.add('A', resumable_inner_sm, {'ok': 'B'})
             StateMachine.add('B', inner_sm, {'ok': 'C'})
@@ -169,16 +172,17 @@ class TestResumableStateMachine(TestCase):
             ContainerSaveState(label='C', userdata=UserData()),
         ])))
 
+
 class TestContainerHistory(TestCase):
     def make_sm(self):
         inner_sm_1 = ResumableStateMachine(outcomes=['ok'], input_keys=['key'], output_keys=['key'])
         inner_sm_2 = ResumableStateMachine(outcomes=['ok'], input_keys=['key'], output_keys=['key'])
         outer_sm = ResumableStateMachine(outcomes=['ok'], input_keys=['key'], output_keys=['key'])
-        
+
         def execute(ud):
             ud['key'] += 1
             return 'ok'
-        
+
         def make_state():
             return CBState(execute, outcomes=['ok'], io_keys=['key'])
 
@@ -225,7 +229,7 @@ class TestContainerHistory(TestCase):
     def test_resume_from_history(self):
         sm = self.make_sm()
         history = ContainerHistory(sm)
-        
+
         parent_ud = UserData()
         parent_ud.key = 0
         outcome = sm.execute(parent_ud)

--- a/pkg/spear_planner/python/spear_planner/test_history.py
+++ b/pkg/spear_planner/python/spear_planner/test_history.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+PKG = 'spear_planner'
+from unittest import TestCase, TestSuite
+from spear_planner.history import Checkpoint, ContainerHistory, ContainerSaveState, ResumableStateMachine
+
+from smach.state_machine import StateMachine
+from smach.state import CBState
+from smach.user_data import UserData
+from uuid import uuid4
+from datetime import datetime
+
+
+class TestResumableStateMachine(TestCase):
+    def setUp(self) -> None:
+        self._trace = []
+
+    def simple_sm(self):
+        sm = ResumableStateMachine(outcomes=['ok'])
+        def execute(name):
+            self._trace.append(name)
+            return 'ok'
+        with sm:
+            StateMachine.add('A', CBState(lambda ud: execute('A'), outcomes=['ok']), {'ok': 'B'})
+            StateMachine.add('B', CBState(lambda ud: execute('B'), outcomes=['ok']), {'ok': 'C'})
+            StateMachine.add('C', CBState(lambda ud: execute('C'), outcomes=['ok']))
+        return sm
+
+    def sm_with_userdata(self):
+        sm = ResumableStateMachine(outcomes=['ok'], input_keys=['key'])
+        def execute(name, outcome):
+            self._trace.append(name)
+            return outcome
+        with sm:
+            StateMachine.add('A', CBState(lambda ud: execute('A', ud['key']), outcomes=['B'], io_keys=['key']), {'B': 'B'})
+            StateMachine.add('B', CBState(lambda ud: execute('B', ud['key']), outcomes=['ok'], input_keys=['key']))
+        return sm
+
+    def nested_sm(self):
+        def execute(name, outcome):
+            self._trace.append(name)
+            return outcome
+
+        resumable_inner_sm = ResumableStateMachine(outcomes=['ok'])
+        inner_sm = StateMachine(outcomes=['ok'])
+        outer_sm = ResumableStateMachine(outcomes=['ok'])
+       
+        with outer_sm:
+            StateMachine.add('A', resumable_inner_sm, {'ok': 'B'})
+            StateMachine.add('B', inner_sm, {'ok': 'C'})
+            StateMachine.add('C', CBState(lambda ud: execute('C', 'ok'), outcomes=['ok']))
+        with resumable_inner_sm:
+            StateMachine.add('A', CBState(lambda ud: execute('A.A', 'ok'), outcomes=['ok']), {'ok': 'B'})
+            StateMachine.add('B', CBState(lambda ud: execute('A.B', 'ok'), outcomes=['ok']))
+        with inner_sm:
+            StateMachine.add('A', CBState(lambda ud: execute('B.A', 'ok'), outcomes=['ok']), {'ok': 'B'})
+            StateMachine.add('B', CBState(lambda ud: execute('B.B', 'ok'), outcomes=['ok']))
+
+        return outer_sm
+
+    def trace(self):
+        return self._trace
+
+    @staticmethod
+    def make_ud(**kwargs):
+        ud = UserData()
+        ud._data.update(kwargs)
+        return ud
+
+    def test_no_resume(self):
+        """
+        Execution works as normal without resuming
+        """
+        sm = self.simple_sm()
+
+        outcome = sm.execute()
+        self.assertEqual(outcome, 'ok')
+        self.assertEqual(self.trace(), ['A', 'B', 'C'])
+
+    def test_resume_to_start(self):
+        """
+        Can resume to initial state
+        """
+        sm = self.simple_sm()
+
+        outcome = sm.execute_from(Checkpoint(uuid4(), datetime.now(), [
+            ContainerSaveState(label='A', userdata=UserData())
+        ]))
+        self.assertEqual(outcome, 'ok')
+        self.assertEqual(self.trace(), ['A', 'B', 'C'])
+
+    def test_resume_to_middle(self):
+        """
+        Can resume to an intermediate state
+        """
+        sm = self.simple_sm()
+
+        outcome = sm.execute_from(Checkpoint(uuid4(), datetime.now(), [
+            ContainerSaveState(label='B', userdata=UserData())
+        ]))
+        self.assertEqual(outcome, 'ok')
+        self.assertEqual(self.trace(), ['B', 'C'])
+
+    def test_resume_to_end(self):
+        """
+        Can resume to final state
+        """
+        sm = self.simple_sm()
+
+        outcome = sm.execute_from(Checkpoint(uuid4(), datetime.now(), [
+            ContainerSaveState(label='C', userdata=UserData())
+        ]))
+        self.assertEqual(outcome, 'ok')
+        self.assertEqual(self.trace(), ['C'])
+
+    def test_resume_with_ud(self):
+        """
+        Can resume with certain userdata
+        """
+        sm = self.sm_with_userdata()
+        outcome = sm.execute_from(Checkpoint(uuid4(), datetime.now(), [
+            ContainerSaveState(label='B', userdata=self.make_ud(key='ok'))
+        ]))
+        self.assertEqual(outcome, 'ok')
+
+    def test_resume_from_with_ud_input_shadow(self):
+        """
+        Before executing a new state, the input keys from the parent userdata
+        are copied into the child userdata. We want resuming to function as if
+        it happens *after* this step, when in reality it happens before, with
+        some trickery to (hopefully) make the difference invisible.
+
+        Input key values from parent userdata should not overwrite values in
+        child userdata upon resume.
+        """
+        sm = self.sm_with_userdata()
+        outcome = sm.execute_from(Checkpoint(uuid4(), datetime.now(), [
+            ContainerSaveState(label='B', userdata=self.make_ud(key='ok'))
+        ]), self.make_ud(key='err'))
+        self.assertEqual(outcome, 'ok')
+
+    def test_nested_sm(self):
+        """
+        Can resume to nested state-machines
+        """
+        sm = self.nested_sm()
+        outcome = sm.execute_from(Checkpoint(uuid4(), datetime.now(), [
+            ContainerSaveState(label='A', userdata=UserData()),
+            ContainerSaveState(label='B', userdata=UserData()),
+        ]))
+        self.assertEqual(outcome, 'ok')
+        self.assertEqual(self.trace(), ['A.B', 'B.A', 'B.B', 'C'])
+
+        # Cannot resume to non-resumable sm
+        self.assertRaises(ValueError, lambda: sm.execute_from(Checkpoint(uuid4(), datetime.now(), [
+            ContainerSaveState(label='B', userdata=UserData()),
+            ContainerSaveState(label='B', userdata=UserData()),
+        ])))
+
+        # Cannot resume to nonexistant state
+        self.assertRaises(ValueError, lambda: sm.execute_from(Checkpoint(uuid4(), datetime.now(), [
+            ContainerSaveState(label='A', userdata=UserData()),
+            ContainerSaveState(label='X', userdata=UserData()),
+        ])))
+
+        # Cannot resume with spec nested deeper than state-machine is
+        self.assertRaises(ValueError, lambda: sm.execute_from(Checkpoint(uuid4(), datetime.now(), [
+            ContainerSaveState(label='A', userdata=UserData()),
+            ContainerSaveState(label='B', userdata=UserData()),
+            ContainerSaveState(label='C', userdata=UserData()),
+        ])))
+
+class TestContainerHistory(TestCase):
+    def make_sm(self):
+        inner_sm_1 = ResumableStateMachine(outcomes=['ok'], input_keys=['key'], output_keys=['key'])
+        inner_sm_2 = ResumableStateMachine(outcomes=['ok'], input_keys=['key'], output_keys=['key'])
+        outer_sm = ResumableStateMachine(outcomes=['ok'], input_keys=['key'], output_keys=['key'])
+        
+        def execute(ud):
+            ud['key'] += 1
+            return 'ok'
+        
+        def make_state():
+            return CBState(execute, outcomes=['ok'], io_keys=['key'])
+
+        with outer_sm:
+            StateMachine.add('A', inner_sm_1, {'ok': 'B'})
+            StateMachine.add('B', inner_sm_2, {'ok': 'C'})
+            StateMachine.add('C', make_state())
+
+        with inner_sm_1:
+            StateMachine.add('A', make_state(), {'ok': 'B'})
+            StateMachine.add('B', make_state())
+
+        with inner_sm_2:
+            StateMachine.add('A', make_state(), {'ok': 'B'})
+            StateMachine.add('B', make_state())
+
+        return outer_sm
+
+    def test_history(self):
+        sm = self.make_sm()
+        history = ContainerHistory(sm)
+
+        parent_ud = UserData()
+        parent_ud.key = 0
+        outcome = sm.execute(parent_ud)
+
+        self.assertEqual(outcome, 'ok')
+        self.assertEqual(parent_ud.key, 5)
+
+        labels = ['.'.join(s.label for s in c.save_states) for c in history._checkpoints]
+        self.assertEqual(labels, ['A', 'A.A', 'A.B', 'B', 'B.A', 'B.B', 'C'])
+
+        uds = [tuple(s.userdata.key for s in c.save_states) for c in history._checkpoints]
+        self.assertEqual(uds, [
+            (0,),
+            (0, 0),
+            (0, 1),
+            (2,),
+            (2, 2),
+            (2, 3),
+            (4,),
+        ])
+
+    def test_resume_from_history(self):
+        sm = self.make_sm()
+        history = ContainerHistory(sm)
+        
+        parent_ud = UserData()
+        parent_ud.key = 0
+        outcome = sm.execute(parent_ud)
+
+        self.assertEqual(outcome, 'ok')
+        self.assertEqual(parent_ud.key, 5)
+
+        checkpoints = list(history.checkpoints)
+        for checkpoint in checkpoints:
+            parent_ud.key = 0
+            outcome = sm.execute_from(checkpoint, parent_ud)
+            self.assertEqual(outcome, 'ok')
+            self.assertEqual(parent_ud.key, 5)
+
+
+class TestHistory(TestSuite):
+    def __init__(self):
+        super().__init__(tests=(TestResumableStateMachine(), TestContainerHistory()))
+
+
+if __name__ == '__main__':
+    import rosunit
+    rosunit.unitrun(PKG, 'test_history', TestHistory)
+    # import unittest
+    # unittest.main()

--- a/pkg/spear_planner/setup.py
+++ b/pkg/spear_planner/setup.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+setup_args = generate_distutils_setup(packages=['spear_planner'],
+                                      package_dir={'': 'python'})
+
+setup(**setup_args)

--- a/spear_rover/libcanard
+++ b/spear_rover/libcanard
@@ -1,1 +1,0 @@
-../submodules/libcanard/

--- a/spear_rover/libcanard
+++ b/spear_rover/libcanard
@@ -1,0 +1,1 @@
+../submodules/libcanard/

--- a/spear_rover/uavcan_dsdl
+++ b/spear_rover/uavcan_dsdl
@@ -1,0 +1,1 @@
+../submodules/uavcan_dsdl/

--- a/spear_rover/uavcan_dsdl
+++ b/spear_rover/uavcan_dsdl
@@ -1,1 +1,0 @@
-../submodules/uavcan_dsdl/


### PR DESCRIPTION
If we want to be able to switch between autonomous and manual operation in competition, it might be useful to have a way to start the state machine from an arbitrary state. This PR adds a subclass to do that, and another class to save the state machine history as it operates.

Contains the changes from #258 which should be merged first.