### PR TITLE
Split cameras into separate files and add webcams

### DIFF
--- a/pkg/spear_simulator/models/rover/TARS_V2.urdf.xacro
+++ b/pkg/spear_simulator/models/rover/TARS_V2.urdf.xacro
@@ -2,67 +2,13 @@
 <!-- created with Phobos 0.8 -->
 
   <robot name="TARS_V2" xmlns:xacro="http://ros.org/wiki/xacro"> 
+    <xacro:include filename="$(find spear_simulator)/models/rover/constants.xacro"/>
     <xacro:include filename="$(find spear_simulator)/models/rover/wheel.urdf.xacro"/>
     <xacro:include filename="$(find spear_simulator)/models/rover/arm.urdf.xacro"/>
+    <xacro:include filename="$(find spear_simulator)/models/rover/zed_cam.urdf.xacro"/>
+    <xacro:include filename="$(find spear_simulator)/models/rover/webcam.urdf.xacro"/>
     
-    <xacro:property name="M_PI" value="3.1415926535897" />
-    <xacro:property name="WHEEL_SEP_LENGTH" value="0.44"/>
-    <xacro:property name="WHEEL_SEP_WIDTH" value="0.44"/>
-    
-    <link name="link_camera_back">
-    </link>
-
-    <link name="link_camera_depth">
-    </link>
-
-    <link name="camera_depth_optical_frame">
-    </link>
-
     <link name="imu_link">
-    </link>
-
-    <gazebo reference="link_camera_depth">  
-      <sensor type="depth" name="camera_depth">
-        <always_on>true</always_on>
-        <update_rate>20.0</update_rate>
-        <camera>
-          <!-- Set camera geometry based on zed cam at 720p -->
-          <!-- 70 degress fov -->
-          <horizontal_fov>1.2217</horizontal_fov>
-          <image>
-            <format>B8G8R8</format>
-            <width>1280</width>
-            <height>720</height>
-          </image>
-          <clip>
-            <near>0.05</near>
-            <far>8.0</far>
-          </clip>
-        </camera>
-        <plugin name="kinect_camera_controller" filename="libgazebo_ros_openni_kinect.so">
-          <cameraName>camera_depth</cameraName>
-          <alwaysOn>true</alwaysOn>
-          <updateRate>100</updateRate>
-          <imageTopicName>rgb/image_raw</imageTopicName>
-          <depthImageTopicName>depth/image_raw</depthImageTopicName>
-          <pointCloudTopicName>depth/points</pointCloudTopicName>
-          <cameraInfoTopicName>rgb/camera_info</cameraInfoTopicName>
-          <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
-          <frameName>camera_depth_optical_frame</frameName>
-          <baseline>0.1</baseline>
-          <distortion_k1>0.0</distortion_k1>
-          <distortion_k2>0.0</distortion_k2>
-          <distortion_k3>0.0</distortion_k3>
-          <distortion_t1>0.0</distortion_t1>
-          <distortion_t2>0.0</distortion_t2>
-          <pointCloudCutoff>0.4</pointCloudCutoff>
-        </plugin>
-
-      </sensor>
-
-    </gazebo>
-
-    <link name="link_camera_front">
     </link>
 
     <link name="base_link">
@@ -170,23 +116,12 @@
     <xacro:wheel side="left" name="backleft" offset="${-WHEEL_SEP_LENGTH/2} ${WHEEL_SEP_WIDTH/2} 0"/>
     <xacro:wheel side="right" name="backright" offset="${-WHEEL_SEP_LENGTH/2} ${-WHEEL_SEP_WIDTH/2} 0"/>
     
-    <joint name="link_camera_back" type="fixed">
-      <origin xyz="-0.315 1e-05 0.3439" rpy="3.14159 1.5708 0"/>
-      <parent link="base_link"/>
-      <child link="link_camera_back"/>
-    </joint>
+    <xacro:zed_cam xyz="0.3 0 0.2" rpy="0 0 0"/>
 
-    <joint name="link_camera_depth" type="fixed">
-      <origin xyz="0.3 0 0.2" rpy="0 0 0"/>
-      <parent link="base_link"/>
-      <child link="link_camera_depth"/>
-    </joint>
-
-    <joint name="camera_depth_optical_frame" type="fixed">
-      <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}"/>
-      <parent link="link_camera_depth"/>
-      <child link="camera_depth_optical_frame"/>
-    </joint>
+    <xacro:webcam name="front" xyz="0.315 -0.11999 0.3439" rpy="0 0 0"/>
+    <xacro:webcam name="back" xyz="-0.315 1e-05 0.3439" rpy="0 0 ${M_PI}"/>
+    <xacro:webcam name="left" xyz="0 0.24 0.3439" rpy="0 0 ${M_PI/2}"/>
+    <xacro:webcam name="right" xyz="0 -0.24 0.3439" rpy="0 0 ${-M_PI/2}"/>
 
     <joint name="imu_link" type="fixed">
       <origin xyz="0 0 0.2" rpy="0 0 0"/>
@@ -194,11 +129,6 @@
       <child link="imu_link"/>
     </joint>
 
-    <joint name="link_camera_front" type="fixed">
-      <origin xyz="0.315 -0.11999 0.3439" rpy="0 1.5708 0"/>
-      <parent link="base_link"/>
-      <child link="link_camera_front"/>
-    </joint>
 
     <joint name="link_suspension_backleft" type="fixed">
       <origin xyz="-0.15754 0.25888 0.07402" rpy="0 0 0"/>
@@ -263,51 +193,4 @@
         <pose>0 0 0 0 0 0</pose> <!--180 _ _-->
       </sensor>
     </gazebo>
-
-    <!-- Camera Center -->
-    <joint name="zed_camera_center_joint" type="fixed">
-        <parent link="base_link"/>
-        <child link="zed_camera_center"/>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-    </joint>
-
-    <link name="zed_camera_center">
-    </link>
-
-<!-- Left Camera -->
-
-    <joint name="zed_left_camera_joint" type="fixed">
-        <parent link="zed_camera_center"/>
-        <child link="zed_left_camera_frame"/>
-        <origin xyz="0 0.06 0" rpy="0 0 0" />
-    </joint>
-
-    <link name="zed_left_camera_frame" />
-
-    <joint name="zed_left_camera_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="-1.57079632679 0.0 -1.57079632679"/>
-        <parent link="zed_left_camera_frame"/>
-        <child link="zed_left_camera_optical_frame"/>
-    </joint>
-
-    <link name="zed_left_camera_optical_frame"/>
-
-<!-- Right Camera -->
-
-    <joint name="zed_right_camera_joint" type="fixed">
-        <parent link="zed_camera_center"/>
-        <child link="zed_right_camera_frame"/>
-        <origin xyz="0 -0.06 0" rpy="0 0 0" />
-    </joint>
-
-    <link name="zed_right_camera_frame" />
-
-    <joint name="zed_right_camera_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="-1.57079632679 0.0 -1.57079632679"/>
-        <parent link="zed_right_camera_frame"/>
-        <child link="zed_right_camera_optical_frame"/>
-    </joint>
-
-    <link name="zed_right_camera_optical_frame"/>
-    
   </robot>

--- a/pkg/spear_simulator/models/rover/constants.xacro
+++ b/pkg/spear_simulator/models/rover/constants.xacro
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<robot name="zed_cam" xmlns:xacro="http://ros.org/wiki/xacro">
+    <xacro:property name="M_PI" value="3.1415926535897" />
+    <xacro:property name="WHEEL_SEP_LENGTH" value="0.44"/>
+    <xacro:property name="WHEEL_SEP_WIDTH" value="0.44"/>
+</robot>

--- a/pkg/spear_simulator/models/rover/materials.xacro
+++ b/pkg/spear_simulator/models/rover/materials.xacro
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_description/urdf/materials.xacro -->
+<!-- For information about colours in rviz vs gazebo, see https://robotics.stackexchange.com/questions/20506/gazebo-not-reading-the-material-color-in-urdf# -->
+<robot>
+
+  <material name="black">
+    <color rgba="0.0 0.0 0.0 1.0"/>
+  </material>
+
+  <material name="blue">
+    <color rgba="0.0 0.0 0.8 1.0"/>
+  </material>
+
+  <material name="green">
+    <color rgba="0.0 0.8 0.0 1.0"/>
+  </material>
+
+  <material name="grey">
+    <color rgba="0.2 0.2 0.2 1.0"/>
+  </material>
+
+  <material name="orange">
+    <color rgba="${255/255} ${108/255} ${10/255} 1.0"/>
+  </material>
+
+  <material name="brown">
+    <color rgba="${222/255} ${207/255} ${195/255} 1.0"/>
+  </material>
+
+  <material name="red">
+    <color rgba="0.8 0.0 0.0 1.0"/>
+  </material>
+
+  <material name="white">
+    <color rgba="1.0 1.0 1.0 1.0"/>
+  </material>
+</robot>

--- a/pkg/spear_simulator/models/rover/webcam.urdf.xacro
+++ b/pkg/spear_simulator/models/rover/webcam.urdf.xacro
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<robot name="zed_cam" xmlns:xacro="http://ros.org/wiki/xacro">
+    <xacro:include filename="$(find spear_simulator)/models/rover/materials.xacro"/>
+    <xacro:macro name="webcam" params="name xyz rpy">
+        <joint name="joint_webcam_${name}" type="fixed">
+            <origin xyz="${xyz}" rpy="${rpy}" />
+            <parent link="base_link" />
+            <child link="link_webcam_${name}" />
+        </joint>
+        <link name="link_webcam_${name}">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="0.05 0.05 0.05" />
+                </geometry>
+                <material name="orange" />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="0.05 0.05 0.05" />
+                </geometry>
+            </collision>
+            <inertial>
+                <mass value="1e-5" />
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <inertia ixx="1e-6" ixy="0" ixz="0" iyy="1e-6" iyz="0" izz="1e-6" />
+            </inertial>
+        </link>
+
+        <gazebo reference="link_webcam_${name}">
+            <material>Gazebo/Orange</material>
+            <sensor type="camera" name="webcam_${name}">
+                <update_rate>30.0</update_rate>
+                <camera name="${name}">
+                    <horizontal_fov>1.3962634</horizontal_fov>
+                    <image>
+                        <width>800</width>
+                        <height>800</height>
+                        <format>R8G8B8</format>
+                    </image>
+                    <clip>
+                        <near>0.2</near>
+                        <far>300</far>
+                    </clip>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0.0</mean>
+                        <stddev>0.007</stddev>
+                    </noise>
+                </camera>
+                <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+                    <alwaysOn>true</alwaysOn>
+                    <updateRate>0.0</updateRate>
+                    <cameraName>webcam_${name}</cameraName>
+                    <frameName>link_webcam_${name}</frameName>
+                </plugin>
+            </sensor>
+        </gazebo>
+    </xacro:macro>
+</robot>

--- a/pkg/spear_simulator/models/rover/wheel.urdf.xacro
+++ b/pkg/spear_simulator/models/rover/wheel.urdf.xacro
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <robot name="wheel" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find spear_simulator)/models/rover/constants.xacro"/>
 
   <xacro:macro name="wheel" params="name side offset">
     <xacro:property name="link_origin" value="0 0 0"/>

--- a/pkg/spear_simulator/models/rover/zed_cam.urdf.xacro
+++ b/pkg/spear_simulator/models/rover/zed_cam.urdf.xacro
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<robot name="zed_cam" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find spear_simulator)/models/rover/constants.xacro"/>
+  <xacro:include filename="$(find zed_models)/urdf/zed_cam.xacro" ns="zed_models"/>
+  
+  <xacro:macro name="zed_cam" params="xyz rpy">
+    
+    <!-- Camera frames -->
+
+    <joint name="link_camera_depth" type="fixed">
+      <origin xyz="${xyz}" rpy="${rpy}"/>
+      <parent link="base_link"/>
+      <child link="link_camera_depth"/>
+    </joint>
+    <link name="link_camera_depth">
+    </link>
+
+    <joint name="camera_depth_optical_frame" type="fixed">
+      <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}"/>
+      <parent link="link_camera_depth"/>
+      <child link="camera_depth_optical_frame"/>
+    </joint>
+    <link name="camera_depth_optical_frame">
+    </link>
+
+    <!-- Gazebo camera plugin -->
+    <gazebo reference="link_camera_depth">  
+      <sensor type="depth" name="camera_depth">
+        <always_on>true</always_on>
+        <update_rate>20.0</update_rate>
+        <camera>
+          <!-- Set camera geometry based on zed cam at 720p -->
+          <!-- 70 degress fov -->
+          <horizontal_fov>1.2217</horizontal_fov>
+          <image>
+            <format>B8G8R8</format>
+            <width>1280</width>
+            <height>720</height>
+          </image>
+          <clip>
+            <near>0.05</near>
+            <far>8.0</far>
+          </clip>
+        </camera>
+        <plugin name="kinect_camera_controller" filename="libgazebo_ros_openni_kinect.so">
+          <cameraName>camera_depth</cameraName>
+          <alwaysOn>true</alwaysOn>
+          <updateRate>100</updateRate>
+          <imageTopicName>rgb/image_raw</imageTopicName>
+          <depthImageTopicName>depth/image_raw</depthImageTopicName>
+          <pointCloudTopicName>depth/points</pointCloudTopicName>
+          <cameraInfoTopicName>rgb/camera_info</cameraInfoTopicName>
+          <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
+          <frameName>camera_depth_optical_frame</frameName>
+          <baseline>0.1</baseline>
+          <distortion_k1>0.0</distortion_k1>
+          <distortion_k2>0.0</distortion_k2>
+          <distortion_k3>0.0</distortion_k3>
+          <distortion_t1>0.0</distortion_t1>
+          <distortion_t2>0.0</distortion_t2>
+          <pointCloudCutoff>0.4</pointCloudCutoff>
+        </plugin>
+      </sensor>
+    </gazebo>
+
+    <!-- ZED camera frames, as expected by zed_ros_wrapper -->
+    <xacro:zed_models.zed_cam base_frame="link_camera_depth"/>
+  
+  </xacro:macro>
+</robot>

--- a/scripts/unpack.sh
+++ b/scripts/unpack.sh
@@ -72,6 +72,7 @@ repos=(
     UofA-SPEAR/uavcan_dsdl:master
     roboticsgroup/roboticsgroup_upatras_gazebo_plugins:master
     machinekoder/ar_track_alvar:noetic-devel
+    UofA-SPEAR/zed-models:main
 )
 
 cd ~/ros/src


### PR DESCRIPTION
- Adds webcams at the front, back, left, and right of the rover
- Moves the ZED camera stuff into its own xacro file
- Uses the ZED camera stl model from zed-ros-wrapper to show the ZED camera in gazebo/rviz

Currently webcams publish to `/webcam_front`, `/webcam_back`, etc. Not sure if this is the right choice, but it's pretty easy to change if necessary.