### PR TITLE
Add worlds with Mars texture

### DIFF
--- a/pkg/spear_simulator/launch/rover.launch
+++ b/pkg/spear_simulator/launch/rover.launch
@@ -1,6 +1,6 @@
 <!-- Launches everything needed to drive the rover by sending Twist messages -->
 <launch>
-  <arg name="world_name" default="$(find spear_simulator)/worlds/ball_find_02.world"/>
+  <arg name="world_name" default="$(find spear_simulator)/worlds/mars/mars-2k.world"/>
   <arg name="gui" default="true"/>
 
   <!-- Launch gazebo to the specified world -->

--- a/pkg/spear_simulator/models/mars-12k/model.config
+++ b/pkg/spear_simulator/models/mars-12k/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Mars 12k</name>
+  <version>1.0</version>
+  <sdf version="1.5">model.sdf</sdf>
+
+  <author>
+    <name>Rain Epp</name>
+    <email>rain.epp@ualberta.ca</email>
+  </author>
+
+  <description>
+    Hills with 12k mars texture
+  </description>
+</model>

--- a/pkg/spear_simulator/models/mars-12k/model.sdf
+++ b/pkg/spear_simulator/models/mars-12k/model.sdf
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<sdf version="1.4">
+    <model name="mars_heightmap_12k">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <heightmap>
+              <uri>file://media/materials/textures/terrain.png</uri>
+              <size>150 150 10.2</size>
+              <pos>0 0 -5</pos>
+            </heightmap>
+          </geometry>
+        </collision>
+
+        <visual name="mars_visual_12k">
+          <geometry>
+            <heightmap>
+              <texture>
+                <diffuse>model://mars-12k/terrain-texture-12k.jpg</diffuse>
+                <normal>file://media/materials/textures/flat_normal.png</normal>
+                <size>150</size>
+              </texture>
+              <uri>file://media/materials/textures/terrain.png</uri>
+              <!-- Change height slighly to avoid re-using the texture cache from other models with this heightmap -->
+              <!-- https://github.com/osrf/gazebo/issues/2604#issuecomment-831819988 -->
+              <size>150 150 10.2</size>
+              <pos>0 0 -5</pos>
+            </heightmap>
+          </geometry>
+        </visual>
+
+      </link>
+    </model>
+</sdf>

--- a/pkg/spear_simulator/models/mars-2k/model.config
+++ b/pkg/spear_simulator/models/mars-2k/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Mars 2k</name>
+  <version>1.0</version>
+  <sdf version="1.5">model.sdf</sdf>
+
+  <author>
+    <name>Rain Epp</name>
+    <email>rain.epp@ualberta.ca</email>
+  </author>
+
+  <description>
+    Hills with 2k mars texture
+  </description>
+</model>

--- a/pkg/spear_simulator/models/mars-2k/model.sdf
+++ b/pkg/spear_simulator/models/mars-2k/model.sdf
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<sdf version="1.4">
+    <model name="mars_heightmap_2k">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <heightmap>
+              <uri>file://media/materials/textures/terrain.png</uri>
+              <size>150 150 10</size>
+              <pos>0 0 -5</pos>
+            </heightmap>
+          </geometry>
+        </collision>
+
+        <visual name="mars_visual_2k">
+          <geometry>
+            <heightmap>
+              <texture>
+                <diffuse>model://mars-2k/terrain-texture-2k-tiled.jpg</diffuse>
+                <normal>file://media/materials/textures/flat_normal.png</normal>
+                <size>25</size>
+              </texture>
+              <uri>file://media/materials/textures/terrain.png</uri>
+              <size>150 150 10</size>
+              <pos>0 0 -5</pos>
+            </heightmap>
+          </geometry>
+        </visual>
+
+      </link>
+    </model>
+</sdf>

--- a/pkg/spear_simulator/models/mars-4k/model.config
+++ b/pkg/spear_simulator/models/mars-4k/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Mars 4k</name>
+  <version>1.0</version>
+  <sdf version="1.5">model.sdf</sdf>
+
+  <author>
+    <name>Rain Epp</name>
+    <email>rain.epp@ualberta.ca</email>
+  </author>
+
+  <description>
+    Hills with 4k mars texture
+  </description>
+</model>

--- a/pkg/spear_simulator/models/mars-4k/model.sdf
+++ b/pkg/spear_simulator/models/mars-4k/model.sdf
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<sdf version="1.4">
+    <model name="mars_heightmap_4k">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <heightmap>
+              <uri>file://media/materials/textures/terrain.png</uri>
+              <size>150 150 10.1</size>
+              <pos>0 0 -5</pos>
+            </heightmap>
+          </geometry>
+        </collision>
+
+        <visual name="mars_visual_4k">
+          <geometry>
+            <heightmap>
+              <texture>
+                <diffuse>model://mars-4k/terrain-texture-4k-tiled.jpg</diffuse>
+                <normal>file://media/materials/textures/flat_normal.png</normal>
+                <size>50</size>
+              </texture>
+              <uri>file://media/materials/textures/terrain.png</uri>
+              <!-- Change height slighly to avoid re-using the texture cache from other models with this heightmap -->
+              <!-- https://github.com/osrf/gazebo/issues/2604#issuecomment-831819988 -->
+              <size>150 150 10.1</size>
+              <pos>0 0 -5</pos>
+            </heightmap>
+          </geometry>
+        </visual>
+
+      </link>
+    </model>
+</sdf>

--- a/pkg/spear_simulator/worlds/mars/mars-12k.world
+++ b/pkg/spear_simulator/worlds/mars/mars-12k.world
@@ -1,0 +1,12 @@
+<!-- Note: the 12k mars texture is not committed to source control and shuold be
+  downloaded from our google drive -->
+<sdf version='1.7'>
+  <world name='default'>
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <include>
+      <uri>model://mars-12k</uri>
+    </include>
+  </world>
+</sdf>

--- a/pkg/spear_simulator/worlds/mars/mars-2k.world
+++ b/pkg/spear_simulator/worlds/mars/mars-2k.world
@@ -1,0 +1,10 @@
+<sdf version='1.7'>
+  <world name='default'>
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <include>
+      <uri>model://mars-2k</uri>
+    </include>
+  </world>
+</sdf>

--- a/pkg/spear_simulator/worlds/mars/mars-4k.world
+++ b/pkg/spear_simulator/worlds/mars/mars-4k.world
@@ -1,0 +1,12 @@
+<!-- Note: the 4k mars texture is not committed to source control and shuold be
+  downloaded from our google drive -->
+<sdf version='1.7'>
+  <world name='default'>
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <include>
+      <uri>model://mars-4k</uri>
+    </include>
+  </world>
+</sdf>


### PR DESCRIPTION
Adds worlds with 2k, 4k, and 12k mars textures (the heightmap has nothing to do with Mars though, it's just a default terrain heightmap that comes with gazebo). Only the 2k texture is committed to source control; the others can be downloaded from google drive if necessary. Also sets the 2k mars world as the default.

There's an annoying issue here (which was likely responsible for several of the previous attempts to do this failing) where gazebo keeps a terrain texture cache that uses the terrain heights, but nothing else, as a key. So I had to vary the terrain heights slightly among the Mars models to make the textures load correctly.