### PR TITLE
Use (angular) position from wheel odometry instead of delta

### DIFF
--- a/pkg/spear_rover/src/hardware.cpp
+++ b/pkg/spear_rover/src/hardware.cpp
@@ -67,14 +67,10 @@ class CASEDriveHardware : public RobotHWChild {
     parent.registerInterface(&wheel_velocity_interface);
 
     canros_client.observe_actuator_status(position_observer(
-        [&](const actuator_id_t id, const command_value_t delta) {
+        [&](const actuator_id_t id, const command_value_t angle) {
           auto it = wheel_infos.find(id);
           if (it != wheel_infos.end()) {
-            // XXX Probably shouldn't give delta for odometry, better to give
-            // speed or position (that way we can safely skip a couple
-            // messages and so we can use read() correctly instead of using a
-            // callback structure.)
-            it->second.pos += delta;
+            it->second.pos = angle;
           }
         }));
   }


### PR DESCRIPTION
This has a number of advantages
  - It's robust against missed odometry messages
  - It matches the fields in `actuator.Status`
  - It limits data transformations at lower abstraction layers (no more accumulation at the hardware interface layer)

...of course it's all academic anyway since we aren't going to have wheel odometry at circ.

Contains the changes from #278 which will have to be merged first.