### PR TITLE
Remove flexbe_app dependency

### DIFF
--- a/pkg/spear_station/launch/flexbe.launch
+++ b/pkg/spear_station/launch/flexbe.launch
@@ -1,3 +1,0 @@
-<launch>
-  <include file="$(find flexbe_app)/launch/flexbe_ocs.launch"/>
-</launch>

--- a/pkg/spear_station/package.xml
+++ b/pkg/spear_station/package.xml
@@ -28,7 +28,6 @@
   <depend>trajectory_msgs</depend>
   
   <!-- Dependencies from launch files -->
-  <exec_depend>flexbe_app</exec_depend>
   <exec_depend>joy</exec_depend>
   <exec_depend>nimbro_service_transport</exec_depend>
   <exec_depend>nimbro_topic_transport</exec_depend>

--- a/scripts/catkin_lint.bash
+++ b/scripts/catkin_lint.bash
@@ -9,7 +9,6 @@ catkin_lint ~/ros/src \
   --skip-pkg rviz_satellite \
   --skip-pkg nimbro_cam_transport \
   --skip-pkg tf_throttle \
-  --skip-pkg flexbe_app \
   --skip-pkg ros_numpy \
   --skip-pkg roboticsgroup_upatras_gazebo_plugins \
   --skip-pkg ar_track_alvar \


### PR DESCRIPTION
I was getting the following error when trying to build the docker image:

ERROR: the following rosdeps failed to install
  apt: command [apt-get install -y ros-melodic-flexbe-app] failed
  apt: Failed to detect successful installation of [ros-melodic-flexbe-app]

This allows the docker build to succeed. We won't be using flexbe for this competition